### PR TITLE
fixes javascript in login.html to match example on: https://developers.g...

### DIFF
--- a/Lesson3/step3/templates/login.html
+++ b/Lesson3/step3/templates/login.html
@@ -50,11 +50,9 @@ function signInCallback(authResult) {
         // Handle or verify the server response if necessary.
         if (result) {
           $('#result').html('Login Successful!</br>'+ result + '</br>Redirecting...');
-          setTimeout(function() {
-            window.location.href = "/restaurant";
-          }, 4000);
-        } else if (authResult['error']) {
-          console.log('There was an error: ' + authResult['error']);
+         setTimeout(function() {
+          window.location.href = "/restaurant";
+         }, 4000);
         } else {
           $('#result').html('Failed to make a server-side call. Check your configuration and console.');
         }
@@ -62,8 +60,10 @@ function signInCallback(authResult) {
       error: function(result) {
         console.log('There was an error: ' + result);
       }
-      
-  }); } }
+    });
+  } else if (authResult['error']) {
+    console.log('There was an error: ' + authResult['error']);          
+  } }
 </script>
 
 


### PR DESCRIPTION
fixes javascript in login.html to match example on: https://developers.google.com/+/web/signin/server-side-flow
This change should be ported to the lesson 4 versions of this file as well...
and the facebook javascript code should be fixed.
I noticed that the formatting here on github doesn't exactly match that in my sublime editor... probably mixing tabs and spaces.  Sorry.