### PR TITLE
Add return statement if there was an error in the access token info

### DIFF
--- a/Lesson2/step5/project.py
+++ b/Lesson2/step5/project.py
@@ -71,6 +71,7 @@ def gconnect():
     if result.get('error') is not None:
         response = make_response(json.dumps(result.get('error')), 500)
         response.headers['Content-Type'] = 'application/json'
+        return response
 
     # Verify that the access token is used for the intended user.
     gplus_id = credentials.id_token['sub']

--- a/Lesson2/step6/project.py
+++ b/Lesson2/step6/project.py
@@ -68,6 +68,7 @@ def gconnect():
     if result.get('error') is not None:
         response = make_response(json.dumps(result.get('error')), 500)
         response.headers['Content-Type'] = 'application/json'
+        return response
 
     # Verify that the access token is used for the intended user.
     gplus_id = credentials.id_token['sub']

--- a/Lesson2/step7/project.py
+++ b/Lesson2/step7/project.py
@@ -66,6 +66,7 @@ def gconnect():
     if result.get('error') is not None:
         response = make_response(json.dumps(result.get('error')), 500)
         response.headers['Content-Type'] = 'application/json'
+        return response
 
     # Verify that the access token is used for the intended user.
     gplus_id = credentials.id_token['sub']

--- a/Lesson3/step1/project.py
+++ b/Lesson3/step1/project.py
@@ -69,6 +69,7 @@ def gconnect():
     if result.get('error') is not None:
         response = make_response(json.dumps(result.get('error')), 500)
         response.headers['Content-Type'] = 'application/json'
+        return response
 
     # Verify that the access token is used for the intended user.
     gplus_id = credentials.id_token['sub']

--- a/Lesson3/step2Quiz/project.py
+++ b/Lesson3/step2Quiz/project.py
@@ -72,6 +72,7 @@ def gconnect():
     if result.get('error') is not None:
         response = make_response(json.dumps(result.get('error')), 500)
         response.headers['Content-Type'] = 'application/json'
+        return response
 
     # Verify that the access token is used for the intended user.
     gplus_id = credentials.id_token['sub']

--- a/Lesson3/step2Solution/project.py
+++ b/Lesson3/step2Solution/project.py
@@ -67,6 +67,7 @@ def gconnect():
     if result.get('error') is not None:
         response = make_response(json.dumps(result.get('error')), 500)
         response.headers['Content-Type'] = 'application/json'
+        return response
 
     # Verify that the access token is used for the intended user.
     gplus_id = credentials.id_token['sub']

--- a/Lesson3/step3/project.py
+++ b/Lesson3/step3/project.py
@@ -73,6 +73,7 @@ def gconnect():
     if result.get('error') is not None:
         response = make_response(json.dumps(result.get('error')), 500)
         response.headers['Content-Type'] = 'application/json'
+        return response
 
     # Verify that the access token is used for the intended user.
     gplus_id = credentials.id_token['sub']

--- a/Lesson4/step1/project.py
+++ b/Lesson4/step1/project.py
@@ -68,6 +68,7 @@ def gconnect():
     if result.get('error') is not None:
         response = make_response(json.dumps(result.get('error')), 500)
         response.headers['Content-Type'] = 'application/json'
+        return response
 
     # Verify that the access token is used for the intended user.
     gplus_id = credentials.id_token['sub']

--- a/Lesson4/step2/project.py
+++ b/Lesson4/step2/project.py
@@ -145,6 +145,7 @@ def gconnect():
     if result.get('error') is not None:
         response = make_response(json.dumps(result.get('error')), 500)
         response.headers['Content-Type'] = 'application/json'
+        return response
 
     # Verify that the access token is used for the intended user.
     gplus_id = credentials.id_token['sub']


### PR DESCRIPTION
It seems that return statement was missed in gconnect function when we verify iIf there was an error in the access token info:
```
@app.route('/gconnect', methods=['POST'])
def gconnect():
......
    # If there was an error in the access token info, abort.
    if result.get('error') is not None:
        response = make_response(json.dumps(result.get('error')), 500)
        response.headers['Content-Type'] = 'application/json'
        return response

......
```
Added return statement in project.py in each step of the project.