### PR TITLE
Fixed bug in gdisconnect()

### DIFF
--- a/Lesson2/step6/project.py
+++ b/Lesson2/step6/project.py
@@ -125,7 +125,7 @@ def gconnect():
 
 @app.route('/gdisconnect')
 def gdisconnect():
-    access_token = login_session['access_token']
+    access_token = login_session['credentials'].access_token
     print 'In gdisconnect access token is %s', access_token
     print 'User name is: ' 
     print login_session['username']
@@ -134,13 +134,13 @@ def gdisconnect():
     	response = make_response(json.dumps('Current user not connected.'), 401)
     	response.headers['Content-Type'] = 'application/json'
     	return response
-    url = 'https://accounts.google.com/o/oauth2/revoke?token=%s' % login_session['access_token']
+    url = 'https://accounts.google.com/o/oauth2/revoke?token=%s' % access_token
     h = httplib2.Http()
     result = h.request(url, 'GET')[0]
     print 'result is '
     print result
     if result['status'] == '200':
-	del login_session['access_token'] 
+	del login_session['credentials'] 
     	del login_session['gplus_id']
     	del login_session['username']
     	del login_session['email']


### PR DESCRIPTION
login_session does not contain 'access_token' at any point in the code. Instead access_token is accessed via login_session['credentials'].access_token, which (login_session['credentials']) needs to be deleted later.