### PR TITLE
Correctly process Facebook OAuth JSON response 

### DIFF
--- a/Lesson4/step2/project.py
+++ b/Lesson4/step2/project.py
@@ -50,16 +50,14 @@ def fbconnect():
         'web']['app_id']
     app_secret = json.loads(
         open('fb_client_secrets.json', 'r').read())['web']['app_secret']
-    url = 'https://graph.facebook.com/oauth/access_token?grant_type=fb_exchange_token&client_id=%s&client_secret=%s&fb_exchange_token=%s' % (
+    url = 'https://graph.facebook.com/v2.4/oauth/access_token?grant_type=fb_exchange_token&client_id=%s&client_secret=%s&fb_exchange_token=%s' % (
         app_id, app_secret, access_token)
     h = httplib2.Http()
     result = h.request(url, 'GET')[1]
+    data = json.loads(result)
 
-    # Use token to get user info from API
-    userinfo_url = "https://graph.facebook.com/v2.4/me"
-    # strip expire tag from access token
-    token = result.split("&")[0]
-
+    # Extract the access token from response
+    token = 'access_token=' + data['access_token']
 
     url = 'https://graph.facebook.com/v2.4/me?%s&fields=name,id,email' % token
     h = httplib2.Http()

--- a/Lesson4/step2/templates/login.html
+++ b/Lesson4/step2/templates/login.html
@@ -12,12 +12,12 @@
 </head>
 
 
-<body>  
+<body>
 
 
 <!-- GOOGLE PLUS SIGN IN-->
 
-          
+
           <div id="signInButton">
           <span class="g-signin"
             data-scope="openid email"
@@ -53,7 +53,7 @@ function signInCallback(authResult) {
          setTimeout(function() {
           window.location.href = "/restaurant";
          }, 4000);
-          
+
 
       } else if (authResult['error']) {
 
@@ -63,7 +63,7 @@ function signInCallback(authResult) {
          }
 
       }
-      
+
   }); } }
 </script>
 
@@ -76,10 +76,10 @@ function signInCallback(authResult) {
   window.fbAsyncInit = function() {
   FB.init({
     appId      : '846524132078825',
-    cookie     : true,  // enable cookies to allow the server to access 
+    cookie     : true,  // enable cookies to allow the server to access
                         // the session
     xfbml      : true,  // parse social plugins on this page
-    version    : 'v2.2' // use version 2.2
+    version    : 'v2.4' // use version 2.4
   });
 
   };
@@ -114,14 +114,14 @@ function signInCallback(authResult) {
          setTimeout(function() {
           window.location.href = "/restaurant";
          }, 4000);
-          
+
 
       } else {
         $('#result').html('Failed to make a server-side call. Check your configuration and console.');
          }
 
       }
-      
+
   });
 
 
@@ -131,7 +131,7 @@ function signInCallback(authResult) {
 
 
 <button>
-         
+
 
           <fb:login-button scope="public_profile,email" onlogin="sendTokenToServer();">
 <a href='javascript:sendTokenToServer()'>Login with Facebook</a>


### PR DESCRIPTION
From version 2.3 of the Graph API, the response when exchanging the short-lived token for the long-lived token is now in JSON format.

This change takes that into account. It also explicitly defines the API version, rather than leaving it to default to the oldest available. It was this that previous left the error undetected.

For full details of this issue, why it happened and the fix, please see my post about this on the forums:

* https://discussions.udacity.com/t/issues-with-facebook-oauth-access-token/233840

In addition, since the Facebook API is at version 2.8, it might be a good idea to update the code to use this version. That will be for a future pull request a discussion.

Thank you for your attention.

Regards,

Steve Wooding.