### PR TITLE
fix: Add type "button" to cancel buttons

### DIFF
--- a/Lesson4/step2/templates/deleteRestaurant.html
+++ b/Lesson4/step2/templates/deleteRestaurant.html
@@ -8,7 +8,7 @@
 	<button type="submit" class="btn btn-default delete" id="submit" type="submit">
 	<span class="glyphicon glyphicon-trash" aria-hidden="true"></span>Delete</button>
 	<a href = '{{url_for('showRestaurants')}}'>
-		<button class="btn btn-default delete">
+		<button class="btn btn-default delete" type="button">
 		<span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Cancel</button>
 	</a>
 

--- a/Lesson4/step2/templates/editmenuitem.html
+++ b/Lesson4/step2/templates/editmenuitem.html
@@ -48,7 +48,7 @@
 					<button type="submit" class="btn btn-default" id="submit" type="submit">
 					<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>Save</button>
 					<a href = '{{url_for('showRestaurants')}}'>
-						<button class="btn btn-default delete">
+						<button class="btn btn-default delete" type="button">
 						<span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Cancel</button>
 					</a>
 				</div>


### PR DESCRIPTION
On the delete and edit pages, when the cancel button is pressed the form is still submitted. This is because the default type of the button tag is "submit". For the cancel button, the type should be set to "button" instead. Then the form will no longer be submitted.