### PR TITLE
fix: Remove deleting keys from login_session in gdisconnect()

### DIFF
--- a/Lesson4/step2/project.py
+++ b/Lesson4/step2/project.py
@@ -251,11 +251,6 @@ def gdisconnect():
     h = httplib2.Http()
     result = h.request(url, 'GET')[0]
     if result['status'] == '200':
-        del login_session['access_token']
-        del login_session['gplus_id']
-        del login_session['username']
-        del login_session['email']
-        del login_session['picture']
         response = make_response(json.dumps('Successfully disconnected.'), 200)
         response.headers['Content-Type'] = 'application/json'
         return response


### PR DESCRIPTION
The current code deletes keys from login_session in both disconnect() and gdisconnect(), which leads to an error when the user tries to log out. To fix this issue and to match the Facebook code, I have removed all the deletions from the gdisconnect() function.